### PR TITLE
Set private to true in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hnr-cafe",
   "version": "1.0.0",
   "description": "hnr-cafe.",
+  "private": true,
   "main": "build.js",
   "scripts": {
     "build": "npm run fmt && run-p build:*",


### PR DESCRIPTION
## What

https://docs.npmjs.com/files/package.json#private

> If you set "private": true in your package.json, then npm will refuse to publish it.
> This is a way to prevent accidental publication of private repositories.