### PR TITLE
Refactoring

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -20,12 +20,11 @@ const genHTML = (): void => {
             "utf-8"
           );
         } else {
-          throw Error("ERROR: Fail to render");
+          throw new Error("ERROR: Fail to render");
         }
       }
     );
   });
-  return;
 };
 
 const genIndexHTML = (): void => {
@@ -44,7 +43,6 @@ const genIndexHTML = (): void => {
       }
     }
   );
-  return;
 };
 
 const genPrivacyPolicyHTML = (): void => {
@@ -56,10 +54,9 @@ const genPrivacyPolicyHTML = (): void => {
         "utf-8"
       );
     } else {
-      throw Error("ERROR: Fail to render privacy-policy.ejs");
+      throw new Error("ERROR: Fail to render privacy-policy.ejs");
     }
   });
-  return;
 };
 
 const gen = (): void => {
@@ -67,7 +64,6 @@ const gen = (): void => {
   genIndexHTML();
   genPrivacyPolicyHTML();
   console.log("DONE.");
-  return;
 };
 
 gen();

--- a/client/ts/bind_button.ts
+++ b/client/ts/bind_button.ts
@@ -18,12 +18,12 @@ const allButtons = (): Element[] => {
 
 export const bindButtons = (): void => {
   allButtons().forEach(button => {
-    button.addEventListener("click", (e: Event) => {
+    button.addEventListener("click", async (e: Event) => {
       if (e.target instanceof HTMLElement) {
         const audio = document.getElementById(`audio-${e.target.id}`);
         if (audio instanceof HTMLAudioElement) {
           audio.currentTime = 0;
-          audio.play();
+          await audio.play();
         }
         if (e.target.textContent) {
           sendEvent(e.target.textContent);

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "build:js": "webpack",
     "build:html": "ts-node --project ./tsconfig.node.json ./build.ts",
     "build:sounds": "cp -r ./client/sounds ./public/sounds",
-    "fmt": "run-p eslint prettier",
+    "fmt": "run-p eslint",
     "eslint": "eslint -c .eslintrc.json \"./**/*.{js,ts}\"",
-    "eslint-fix": "eslint --fix -c .eslintrc.json \"./**/*.{js,ts}\"",
-    "prettier": "prettier -c \"./**/*.{js,ts}\"",
-    "prettier-fix": "prettier --write \"./**/*.{js,ts}\""
+    "eslint-fix": "eslint --fix -c .eslintrc.json \"./**/*.{js,ts}\""
   },
   "author": "hieki",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "hnr-cafe.",
   "private": true,
-  "main": "build.js",
   "scripts": {
     "build": "npm run fmt && run-p build:*",
     "build:js": "webpack",


### PR DESCRIPTION
- Prettier は ESLint に統合されているので、npm script から除外する
- 意味のない return を取り除く
- `audio.play()` で返ってくる Promise を await するようにする
- `package.json` で指定していた main を削除する
- `throw Error()` => `throw new Error()`